### PR TITLE
Feat: Add core data resources

### DIFF
--- a/Data/Resources/PotionRecipes/Potion of Strength.tres
+++ b/Data/Resources/PotionRecipes/Potion of Strength.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="PotionRecipe" load_steps=3 format=3 uid="uid://ccyqu7aabnnyq"]
+
+[ext_resource type="Script" uid="uid://522kq5mvxrph" path="res://Scripts/Resources/Property.gd" id="1_cug0o"]
+[ext_resource type="Script" uid="uid://dbmrdw48t75pw" path="res://Scripts/Resources/PotionRecipe.gd" id="2_l7i0u"]
+
+[resource]
+script = ExtResource("2_l7i0u")
+name = "Potion of Strength"
+required_properties = Dictionary[ExtResource("1_cug0o"), int]({})
+forbidden_properties = Array[ExtResource("1_cug0o")]([])
+max_impurity_percent = 0.5
+metadata/_custom_type_script = "uid://dbmrdw48t75pw"

--- a/Data/Resources/Processes/Grinding.tres
+++ b/Data/Resources/Processes/Grinding.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="Process" load_steps=2 format=3 uid="uid://mhpwy6dosmjf"]
+
+[ext_resource type="Script" uid="uid://3x6xj612voif" path="res://Scripts/Resources/Process.gd" id="1_nk3jw"]
+
+[resource]
+script = ExtResource("1_nk3jw")
+name = "Grinding"
+duration = 3.0
+required_input_state = Array[int]([])
+output_state = 0
+unlocked = false
+metadata/_custom_type_script = "uid://3x6xj612voif"

--- a/Data/Resources/Properties/Strength.tres
+++ b/Data/Resources/Properties/Strength.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="Property" load_steps=2 format=3 uid="uid://cai6r8iw5bvdk"]
+
+[ext_resource type="Script" uid="uid://522kq5mvxrph" path="res://Scripts/Resources/Property.gd" id="1_8mf4u"]
+
+[resource]
+script = ExtResource("1_8mf4u")
+name = "Strength"
+description = ""
+color = Color(0.73121, 0.533046, 0.175694, 1)
+metadata/_custom_type_script = "uid://522kq5mvxrph"

--- a/Data/Resources/Properties/Vitality.tres
+++ b/Data/Resources/Properties/Vitality.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="Property" load_steps=2 format=3 uid="uid://carr3ccj8sncl"]
+
+[ext_resource type="Script" uid="uid://522kq5mvxrph" path="res://Scripts/Resources/Property.gd" id="1_6mvsg"]
+
+[resource]
+script = ExtResource("1_6mvsg")
+name = "Vitality"
+description = ""
+color = Color(0.863932, 0.149956, 0.213975, 1)
+metadata/_custom_type_script = "uid://522kq5mvxrph"

--- a/Scripts/Globals/GlobalEnums.gd
+++ b/Scripts/Globals/GlobalEnums.gd
@@ -1,0 +1,13 @@
+class_name GlobalEnums
+extends RefCounted
+# I use RefCounted and not Node because I will not be adding this to the scene tree
+# Я использую RefCounted, а не Node, потому что я не буду добавлять это ни в какую сцену
+
+enum SubstanceState {
+	RAW,
+	SOLID,
+	GROUND,
+	LIQUID,
+	GAS,
+	ASH
+}

--- a/Scripts/Globals/GlobalEnums.gd.uid
+++ b/Scripts/Globals/GlobalEnums.gd.uid
@@ -1,0 +1,1 @@
+uid://csoin7v4p5p2j

--- a/Scripts/Resources/Ingredient.gd
+++ b/Scripts/Resources/Ingredient.gd
@@ -1,0 +1,7 @@
+class_name Ingredient
+extends Resource
+
+@export var name: String = ""
+@export var description: String = ""
+@export var icon: Texture2D
+@export var base_properties: Dictionary[Property, int]

--- a/Scripts/Resources/Ingredient.gd.uid
+++ b/Scripts/Resources/Ingredient.gd.uid
@@ -1,0 +1,1 @@
+uid://cd5o8bt0ebwaa

--- a/Scripts/Resources/PotionRecipe.gd
+++ b/Scripts/Resources/PotionRecipe.gd
@@ -1,0 +1,7 @@
+class_name PotionRecipe
+extends Resource
+
+@export var name: String = ""
+@export var required_properties: Dictionary[Property, int]
+@export var forbidden_properties: Array[Property]
+@export var max_impurity_percent: float = 0.5

--- a/Scripts/Resources/PotionRecipe.gd.uid
+++ b/Scripts/Resources/PotionRecipe.gd.uid
@@ -1,0 +1,1 @@
+uid://dbmrdw48t75pw

--- a/Scripts/Resources/Process.gd
+++ b/Scripts/Resources/Process.gd
@@ -1,0 +1,8 @@
+class_name Process
+extends Resource
+
+@export var name: String = ""
+@export var duration: float = 3.0
+@export var required_input_state: Array[GlobalEnums.SubstanceState]
+@export var output_state: GlobalEnums.SubstanceState
+@export var unlocked: bool = false

--- a/Scripts/Resources/Process.gd.uid
+++ b/Scripts/Resources/Process.gd.uid
@@ -1,0 +1,1 @@
+uid://3x6xj612voif

--- a/Scripts/Resources/Property.gd
+++ b/Scripts/Resources/Property.gd
@@ -1,0 +1,7 @@
+class_name Property
+extends Resource
+
+@export var name: String = ""
+@export var description: String = ""
+@export var color: Color = Color.WHITE
+var potency: int = -1

--- a/Scripts/Resources/Property.gd.uid
+++ b/Scripts/Resources/Property.gd.uid
@@ -1,0 +1,1 @@
+uid://522kq5mvxrph


### PR DESCRIPTION
Sets up foundational data resources for the game. This allows for creating anything for alchemy extremely simple.

- Added 'Property' resource
- Added 'Ingredient' resource
- Added 'Process' resource
- Added 'PotionRecipe' resource
- Added 'GlobalEnums' for shared types like 'SubstanceState'